### PR TITLE
Do not upgrade setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9-slim
 
 RUN apt-get update && apt-get install --yes sudo vim git-core && \
     apt clean && \
-    python3 -m pip --no-cache-dir install --upgrade pip setuptools && \
+    python3 -m pip install --no-cache-dir "pip<24" "setuptools<70" && \
     useradd -u 65500 -m rally && \
     usermod -aG sudo rally && \
     echo "rally ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/00-rally-user && \


### PR DESCRIPTION
With latest python3.9-slim image pkg_resources not exist anymore, because we update setuptools in Dockerfile it triggers
ModuleNotFoundError: No module named 'pkg_resources'. This patch delete update setuptools from Dockerfile.